### PR TITLE
Use kebab-case in test function names

### DIFF
--- a/t/01-basics.t
+++ b/t/01-basics.t
@@ -10,21 +10,21 @@ my $p3 = Math::Polynomial.new();
 my $p4 = Math::Polynomial.new(1.0);
 my $p5 = Math::Polynomial.new(0, 0, 3, 5, 6, 0.0, 0);
 
-isa_ok($p, Math::Polynomial, "Variable is of type Math::Polynomial");
-isa_ok($p2, Math::Polynomial, "Variable is of type Math::Polynomial");
-isa_ok($p3, Math::Polynomial, "Variable is of type Math::Polynomial");
-isa_ok($p4, Math::Polynomial, "Variable is of type Math::Polynomial");
-isa_ok($p5, Math::Polynomial, "Variable is of type Math::Polynomial");
+isa-ok($p, Math::Polynomial, "Variable is of type Math::Polynomial");
+isa-ok($p2, Math::Polynomial, "Variable is of type Math::Polynomial");
+isa-ok($p3, Math::Polynomial, "Variable is of type Math::Polynomial");
+isa-ok($p4, Math::Polynomial, "Variable is of type Math::Polynomial");
+isa-ok($p5, Math::Polynomial, "Variable is of type Math::Polynomial");
 
 ok $p3.is-zero, "Empty Math::Polynomial.new generates zero polynomial";
 is(~$p, "3 x^2 + 2 x^1 + 1 x^0", "Math::Polynomial.Str works correctly");
 is(~EVAL($p.perl), ~$p, ".perl works, tested with Str");
-isa_ok(EVAL($p.perl), Math::Polynomial, ".perl works, tested with isa");
+isa-ok(EVAL($p.perl), Math::Polynomial, ".perl works, tested with isa");
 
 is($p5.coefficients.elems, 5, "Leading zero coefficients deleted");
 
-is_approx($p.evaluate(0.0), 1.0, "\$p.evaluate(0.0) == 1");
-is_approx($p.evaluate(1.0), 6.0, "\$p.evaluate(1.0) == 6");
+is-approx($p.evaluate(0.0), 1.0, "\$p.evaluate(0.0) == 1");
+is-approx($p.evaluate(1.0), 6.0, "\$p.evaluate(1.0) == 6");
 
 my $sum = $p + -$p;
 ok $sum.is-zero, "p + (-p) is the zero polynomial";
@@ -33,77 +33,77 @@ $sum = $p + $p2;
 
 for ^10 -> $x
 {
-    is_approx($sum.evaluate($x), $p.evaluate($x) + $p2.evaluate($x), "sum = p + p2 for $x");
+    is-approx($sum.evaluate($x), $p.evaluate($x) + $p2.evaluate($x), "sum = p + p2 for $x");
 }
 
 $sum = $sum + 3;  # was +=, but that doesn't work any more
 for ^10 -> $x
 {
-    is_approx($sum.evaluate($x), $p.evaluate($x) + $p2.evaluate($x) + 3, "sum + 3 = p + p2 + 3 for $x");
+    is-approx($sum.evaluate($x), $p.evaluate($x) + $p2.evaluate($x) + 3, "sum + 3 = p + p2 + 3 for $x");
 }
 
 $sum = 5 + $sum;
 for ^10 -> $x
 {
-    is_approx($sum.evaluate($x), $p.evaluate($x) + $p2.evaluate($x) + 8, "5 + (sum + 3) = p + p2 + 8 for $x");
+    is-approx($sum.evaluate($x), $p.evaluate($x) + $p2.evaluate($x) + 8, "5 + (sum + 3) = p + p2 + 8 for $x");
 }
 
 $sum = -$sum;
 for ^10 -> $x
 {
-    is_approx($sum.evaluate($x), -($p.evaluate($x) + $p2.evaluate($x) + 8), "-(5 + (sum + 3)) = -(p + p2 + 8) for $x");
+    is-approx($sum.evaluate($x), -($p.evaluate($x) + $p2.evaluate($x) + 8), "-(5 + (sum + 3)) = -(p + p2 + 8) for $x");
 }
 
 my $product = $sum * $p4;
 for ^10 -> $x
 {
-    is_approx($product.evaluate($x), $sum.evaluate($x), "sum * (1 x^0) = sum for $x");
+    is-approx($product.evaluate($x), $sum.evaluate($x), "sum * (1 x^0) = sum for $x");
 }
 
 $product = $sum * $p3;
 for ^10 -> $x
 {
-    is_approx($product.evaluate($x), 0.0, "sum * (0 x^0) = 0 for $x");
+    is-approx($product.evaluate($x), 0.0, "sum * (0 x^0) = 0 for $x");
 }
 
 $product = $sum * 1;
 for ^10 -> $x
 {
-    is_approx($product.evaluate($x), $sum.evaluate($x), "sum * 1 = sum for $x");
+    is-approx($product.evaluate($x), $sum.evaluate($x), "sum * 1 = sum for $x");
 }
 
 $product = $sum * 0;
 for ^10 -> $x
 {
-    is_approx($product.evaluate($x), 0.0, "sum * 0 = 0 for $x");
+    is-approx($product.evaluate($x), 0.0, "sum * 0 = 0 for $x");
 }
 
 $product = 2.5 * $sum;
 for ^10 -> $x
 {
-    is_approx($product.evaluate($x), 2.5 * $sum.evaluate($x), "sum * 2.5 = sum * 2.5 for $x");
+    is-approx($product.evaluate($x), 2.5 * $sum.evaluate($x), "sum * 2.5 = sum * 2.5 for $x");
 }
 
 $product = 1 * $sum;
 for ^10 -> $x
 {
-    is_approx($product.evaluate($x), $sum.evaluate($x), "sum * 1 = sum for $x");
+    is-approx($product.evaluate($x), $sum.evaluate($x), "sum * 1 = sum for $x");
 }
 
 $product = 0 * $sum;
 for ^10 -> $x
 {
-    is_approx($product.evaluate($x), 0.0, "sum * 0 = 0 for $x");
+    is-approx($product.evaluate($x), 0.0, "sum * 0 = 0 for $x");
 }
 
 $product = $p * $p2;
 for ^10 -> $x
 {
-    is_approx($product.evaluate($x), $p.evaluate($x) * $p2.evaluate($x), "product = p * p2 for $x");
+    is-approx($product.evaluate($x), $p.evaluate($x) * $p2.evaluate($x), "product = p * p2 for $x");
 }
 
 $product = $product / 5.5;  # was /=, but that doesn't work in current Rakudo
 for ^10 -> $x
 {
-    is_approx($product.evaluate($x), $p.evaluate($x) * $p2.evaluate($x) / 5.5, "product / 5.5 = p * p2 / 5.5 for $x");
+    is-approx($product.evaluate($x), $p.evaluate($x) * $p2.evaluate($x) / 5.5, "product / 5.5 = p * p2 / 5.5 for $x");
 }

--- a/t/02_basics.t
+++ b/t/02_basics.t
@@ -26,7 +26,7 @@ for @samples -> $sample {
     my @res1 = $sample[1].flat;
     my $p = Math::Polynomial.new(@arg);
     ok $p.defined, '$p is defined';
-    isa_ok $p, Math::Polynomial, '$p is a Math::Polynomial';
+    isa-ok $p, Math::Polynomial, '$p is a Math::Polynomial';
     is $p.coefficients, @res1, '$p has the proper coefficients';
 }
 
@@ -36,7 +36,7 @@ for @samples -> $sample {
     my @res1 = $sample[1].flat;
     my $p = $sp.new(@arg);
     ok $p.defined, '$p is defined';
-    isa_ok $p, Math::Polynomial, '$p is a Math::Polynomial';
+    isa-ok $p, Math::Polynomial, '$p is a Math::Polynomial';
     is $p.coefficients, @res1, '$p has the proper coefficients';
 }
  
@@ -56,7 +56,7 @@ for @samples -> $sample {
     my @res = $sample[1].flat;
     my $p = Math::Polynomial.monomial(|@arg);
     ok $p.defined, '$p is defined';
-    isa_ok $p, Math::Polynomial, '$p is a Math::Polynomial';
+    isa-ok $p, Math::Polynomial, '$p is a Math::Polynomial';
     is $p.coefficients, @res, '$p has the proper coefficients';
 }
 
@@ -65,7 +65,7 @@ for @samples -> $sample {
     my @res = $sample[1].flat;
     my $p = $sp.monomial(|@arg);
     ok $p.defined, '$p is defined';
-    isa_ok $p, Math::Polynomial, '$p is a Math::Polynomial';
+    isa-ok $p, Math::Polynomial, '$p is a Math::Polynomial';
     is $p.coefficients, @res, '$p has the proper coefficients';
 }
 

--- a/t/04_lagrange.t
+++ b/t/04_lagrange.t
@@ -51,13 +51,13 @@ ok(has_coeff($z1));
 my $z2 = Math::Polynomial.interpolate([], []);
 ok(has_coeff($z2));
 
-dies_ok { $p.interpolate([1], [2, 3]) }, "Arrays must be equal length";
+dies-ok { $p.interpolate([1], [2, 3]) }, "Arrays must be equal length";
 # ok($@ =~ /usage/);
 
-dies_ok { $p.interpolate([1], 2) }, "Both arguments must be arrays";
+dies-ok { $p.interpolate([1], 2) }, "Both arguments must be arrays";
 # ok($@ =~ /usage/);
  
-dies_ok { $p.interpolate(1, [2]) }, "Both arguments must be arrays";
+dies-ok { $p.interpolate(1, [2]) }, "Both arguments must be arrays";
 # ok($@ =~ /usage/);
 
 # $r = EVAL { $p.interpolate([1, 1], [2, 2]) };

--- a/t/11_math_bigrat.t
+++ b/t/11_math_bigrat.t
@@ -33,7 +33,7 @@ ok $p == $q;
 
 my $x = $p.monomial(1);
 my $y = $x - $p.coeff-one;
-isa_ok $y, Math::Polynomial, '$y is indeed a Math::Polynomial';
+isa-ok $y, Math::Polynomial, '$y is indeed a Math::Polynomial';
 ok 1 == $y.degree;
 ok $p.coeff-zero == $y.evaluate($x3);
 


### PR DESCRIPTION
Test function names with underscores have been deprecated in favour of their
kebab-case variants.  The deprecated form will be removed in Rakudo 2015.09.
This change brings the test suite up to date with current Rakudo.